### PR TITLE
Remove cursor pointer because is not needed

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1402,7 +1402,6 @@ h5 {
     position: relative;
     padding: 0;
     text-align: left;
-    cursor: pointer;
     background-color: #fff;
     transition: all .15s ease
 }


### PR DESCRIPTION
En el schedule, la clase CSS `event-card` se usa en `div` y `a`.

Los `a` tienen cursor pointer por defecto y lo usan para navegar a la descripción detallada del orador. Los `div`s no tienen cursor pointer y lo están usando para marcar los desayunos, meriendas, registración, etc, que no necesitan navegar, por ende, no necesitan cursor pointer.